### PR TITLE
Change defaults for run_train_model.sh for use with k8s. 

### DIFF
--- a/lj_common_model.py
+++ b/lj_common_model.py
@@ -152,7 +152,7 @@ def create_parser():
                         help='initial model learning rate')
     parser.add_argument('--lr', default=0.001, type=float,
                         help='optimizer learning rate')
-    parser.add_argument('--dim', default=128, type=int,
+    parser.add_argument('--dim', default=512, type=int,
                         help='dimensionality of embeddings')
     parser.add_argument('--output-dim', default=0, type=int,
                         help='n trained classes; if 0 use training set (for eval only)')
@@ -169,7 +169,7 @@ def create_parser():
                         help='evaluate model only')
     parser.add_argument('--base-log-dir', default=".", type=str,
                         help = 'base directory for all logs')
-    parser.add_argument('--input-size', default=650, type=int,
+    parser.add_argument('--input-size', default=640, type=int,
                         help='resize images to this size for input')
     parser.add_argument('--input-crop', default=600, type=int,
                         help='random crop images to this size')

--- a/run_train_model.sh
+++ b/run_train_model.sh
@@ -15,20 +15,20 @@
 #  'output-tag'
 
 backbone=${BACKBONE:-"tf_efficientnetv2_m"}
-input_size=${INPUT_SIZE:-320}
-input_crop=${INPUT_CROP:-300}
+input_size=${INPUT_SIZE:-640}
+input_crop=${INPUT_CROP:-600}
 
 batch_size=${BATCH_SIZE:-32}
 embedding_dim=${EMBEDDING_DIM:-512}
-epochs=${EPOCHS:-30}
-rand_config=${RAND_CONFIG:-"rand-mstd1"}
+epochs=${EPOCHS:-60}
+rand_config=${RAND_CONFIG:-"rand-m5-mstd0.1"}
 
 # input / output data
 results_dir=${RESULTS_DIR:-"/mnt/data/results/triplet-learning"}
 data_dir=${DATA_DIR:-"/mnt/data/triplet-learning"}
 output_bucket=${OUTPUT_BUCKET:-"gs://ljcv-model-artifacts"}
 top_level_output=${TOP_LEVEL_OUTPUT:-"pytorch-metric-learning"}
-result_output_dir=${RESULT_OUTPUT_DIR:-"20240621"}
+result_output_dir=${RESULT_OUTPUT_DIR:-"20240828"}
 output_tag=${OUTPUT_TAG:-"pymetric.effv2_m.b${batch_size}.dim${embedding_dim}.im${input_size}.defs"}
 
 output_target=${output_bucket}/${top_level_output}


### PR DESCRIPTION
Change defaults in run_train_model.sh for best current understanding of generally good set of parameters.

Minor changes in standard parser arguments.